### PR TITLE
PR58 - Padrão de cadastro comum

### DIFF
--- a/src/components/structured/stepper/Stepper.jsx
+++ b/src/components/structured/stepper/Stepper.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import * as Multistep from "react-form-stepper";
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import { Button } from "reactstrap";
 import StepWizard from "react-step-wizard";
+import * as Multistep from "react-form-stepper";
 
 import { COLORS } from "../../../themes/colors";
 import RegisterPanel from "../../../layouts/panel/register-panel/RegisterPanel";


### PR DESCRIPTION
Alterações do commit original: 

<a href="[/about/about_team.htm](https://github.com/Dispo-Empresa/Dispo-Client/commit/eaeb19e50c224c1bdbed571ac18ed0dda0f0e18a)">PR58-Padrão de registro</a>

- Padrão de formulário de cadastro
- Divisão de conteúdo dentro do cadastro
- Símbolos de obrigatoriedade e dicas nas textfieds
- Placeholder nas textfields que o Matheus e guigas ja tinham dado a ideia, só implementei pra ir pra master
- Convenção para campos e validações de primeira camada para cada campo específico
- Selectfields com X quando não é required